### PR TITLE
update error messages

### DIFF
--- a/src/ErrorMessages.jl
+++ b/src/ErrorMessages.jl
@@ -25,7 +25,6 @@ err_linfo_color()   = repl_color("JULIA_ERR_LINFO_COLOR", :bold)
 err_funcdef_color() = repl_color("JULIA_ERR_FUNCDEF_COLOR", :bold)
 
 # TODO: Get rid of these globals..
-n_frames = Ref{Int}(0)
 linfos = []
 stack_counter = Ref{Int}(0)
 


### PR DESCRIPTION
This changes the default error messages to what @pabloferz suggested in https://github.com/JuliaLang/julia/pull/18228#issuecomment-245882983:

![image](https://cloud.githubusercontent.com/assets/1282691/18410402/51199a70-7762-11e6-96cc-c733d3e3d74b.png)

For those of you who like the new line before the file name and line number there is a new `ENV` variable `JULIA_ERR_LINFO_NEWLINE` which if set will print like the previous way:

![image](https://cloud.githubusercontent.com/assets/1282691/18410410/8752e4b6-7762-11e6-9f52-920db48536e4.png)

I am in progress of writing docs for all the options and stuff.