### PR TITLE
Limit error message length

### DIFF
--- a/src/errormessage_overrides.jl
+++ b/src/errormessage_overrides.jl
@@ -46,12 +46,12 @@ function Base.showerror(io::IO, ex, bt; backtrace=true)
         end
         try
             Base.with_output_color(default_color_warn, io) do io
-                showerror(io, ex)
+                showerror(IOContext(io, :limit => true), ex)
             end
         end
     else
         try
-            showerror(io, ex)
+            showerror(IOContext(io, :limit => true), ex)
         finally
             backtrace && show_backtrace(io, bt)
         end


### PR DESCRIPTION
Fixes same error as here: https://github.com/JuliaLang/julia/pull/18726.

There is one more showerror which did not like the `:limit => true` addition: https://github.com/KristofferC/OhMyREPL.jl/blob/91779c695104bc6e768edebc1ad92e7016948a0d/src/errormessage_overrides.jl#L26 Not sure why this is.