### PR TITLE
Highlight macro with parentheses correctly

### DIFF
--- a/src/passes/SyntaxHighlighter.jl
+++ b/src/passes/SyntaxHighlighter.jl
@@ -197,7 +197,7 @@ add_pass!(PASS_HANDLER, "SyntaxHighlighter", SYNTAX_HIGHLIGHTER_SETTINGS, false)
             ansitokens[i] = cscheme.comment
         # function f(...)
         elseif kind(t) == Tokens.LPAREN && kind(prev_t) == Tokens.IDENTIFIER
-            ansitokens[i-1] = cscheme.call
+            (i > 2 && exactkind(tokens[i-2]) == Tokens.AT_SIGN) || (ansitokens[i-1] = cscheme.call)
              # function f(...)
             if i > 3 && kind(tokens[i-2]) == Tokens.WHITESPACE && exactkind(tokens[i-3]) == Tokens.FUNCTION
                 ansitokens[i-1] = cscheme.function_def

--- a/test/test_highlighter.jl
+++ b/test/test_highlighter.jl
@@ -19,7 +19,7 @@ println("Highlighted string: ", String(take!(b)))
 
 println()
 
-str = "(function :foobar, foobar )# foobar"
+str = "(function :foobar, foobar @foobar())# foobar"
 OhMyREPL.test_passes(b, OhMyREPL.PASS_HANDLER, str, 3)
 
 println("Original string: ", str)


### PR DESCRIPTION
Previously function call syntax would override macro highlighting when using an opening `(`. (Note sure of what the best way to check for this was, so if you've got a better approach that would be good.)