### PR TITLE
Add tomorrow night bright color scheme

### DIFF
--- a/src/passes/SyntaxHighlighter.jl
+++ b/src/passes/SyntaxHighlighter.jl
@@ -86,6 +86,7 @@ activate!(sh::SyntaxHighlighterSettings, name::String) = sh.active = sh.schemes[
 add!(SYNTAX_HIGHLIGHTER_SETTINGS, "Monokai256", _create_monokai_256())
 add!(SYNTAX_HIGHLIGHTER_SETTINGS, "Monokai16", _create_monokai())
 add!(SYNTAX_HIGHLIGHTER_SETTINGS, "BoxyMonokai256", _create_boxymonokai_256())
+add!(SYNTAX_HIGHLIGHTER_SETTINGS, "TomorrowNightBright", _create_tomorrow_night_bright())
 # Added by default
 # add!(SYNTAX_HIGHLIGHTER_SETTINGS, "JuliaDefault", _create_juliadefault())
 
@@ -150,5 +151,3 @@ add_pass!(PASS_HANDLER, "SyntaxHighlighter", SYNTAX_HIGHLIGHTER_SETTINGS, false)
 end
 
 end
-
-

--- a/src/passes/colorschemes.jl
+++ b/src/passes/colorschemes.jl
@@ -69,3 +69,20 @@ function _create_boxymonokai_256()
     number!(cs, ANSIToken(foreground = 208))
     return cs
 end
+
+function _create_tomorrow_night_bright()
+    cs = ColorScheme()
+    symbol!(cs, ANSIToken(foreground = 185))
+    comment!(cs, ANSIToken(foreground = 246))
+    string!(cs, ANSIToken(foreground = 185))
+    call!(cs, ANSIToken(foreground = 73))
+    op!(cs, ANSIToken(foreground = 231))
+    keyword!(cs, ANSIToken(foreground = 140))
+    text!(cs, ANSIToken(foreground = :default))
+    macro!(cs, ANSIToken(foreground = 73))
+    function_def!(cs, ANSIToken(foreground = 110))
+    error!(cs, ANSIToken(foreground = :default))
+    argdef!(cs, ANSIToken(foreground = 255)) # nothing special added here
+    number!(cs, ANSIToken(foreground = 208))
+    return cs
+end


### PR DESCRIPTION
This is a first pass - the colors are the closest I could get using `Colors.colordiff` with the function referenced in #63 - it surprisingly does not look very bright, though. This is how it looks in iTerm2 (for the Mac):
![skaermbillede 2017-04-27 kl 12 47 36](https://cloud.githubusercontent.com/assets/8429802/25480204/163d49ca-2b48-11e7-82a4-d46615354386.png)
