### PR TITLE
add noop for buffer of IOBuffer

### DIFF
--- a/src/repl.jl
+++ b/src/repl.jl
@@ -65,6 +65,8 @@ function rewrite_with_ANSI(s, cursormove::Bool = false)
 end
 
 
+buffer(io::IOBuffer) = io
+
 function create_keybindings()
 
     D = Dict{Any, Any}()


### PR DESCRIPTION
This appears to be needed to make the Home key work again. Otherwise I get:

```
ERROR (in the keymap): MethodError: no method matching buffer(::Base.AbstractIOBuffer{Array{UInt8,1}})
Closest candidates are:
  buffer(::Base.LineEdit.PrefixSearchState) at LineEdit.jl:1596
  buffer(::Base.LineEdit.SearchState) at LineEdit.jl:1595
  buffer(::Base.LineEdit.PromptState) at LineEdit.jl:1594
  ...
Stacktrace:
 [1] (::OhMyREPL.Prompt.##10#37)(::Base.LineEdit.MIState, ::Base.REPL.LineEditREPL, ::String) at /home/kristoffer/.julia/v0.6/OhMyREPL/src/repl.jl:87
 [2] (::Base.LineEdit.##13#14{OhMyREPL.Prompt.##10#37,String})(::Base.LineEdit.MIState, ::Base.REPL.LineEditREPL) at ./LineEdit.jl:740
 [3] prompt!(::Base.Terminals.TTYTerminal, ::Base.LineEdit.ModalInterface, ::Base.LineEdit.MIState) at ./LineEdit.jl:1618
 [4] run_interface(::Base.Terminals.TTYTerminal, ::Base.LineEdit.ModalInterface) at ./LineEdit.jl:1578
 [5] run_frontend(::Base.REPL.LineEditREPL, ::Base.REPL.REPLBackendRef) at ./REPL.jl:945
 [6] run_repl(::Base.REPL.LineEditREPL, ::Base.##507#508) at ./REPL.jl:180
 [7] _start() at ./client.jl:413
```

@keno