### PR TITLE
Avoid type piracy on Base.LineEdit.buffer

### DIFF
--- a/src/BracketInserter.jl
+++ b/src/BracketInserter.jl
@@ -9,11 +9,12 @@ mutable struct BracketInserterSettings
     complete_brackets::Bool
 end
 
-import Base.LineEdit: edit_insert, edit_move_left, edit_move_right, buffer, char_move_left,
+import Base.LineEdit: edit_insert, edit_move_left, edit_move_right, char_move_left,
                       edit_backspace, terminal, transition, state
 
 import Base.Terminals.beep
 import OhMyREPL.Prompt.rewrite_with_ANSI
+import OhMyREPL.buffer
 
 const BRACKET_INSERTER = BracketInserterSettings(true)
 

--- a/src/OhMyREPL.jl
+++ b/src/OhMyREPL.jl
@@ -17,6 +17,10 @@ include(joinpath("passes", "Passes.jl"))
 include("BracketInserter.jl")
 include("prompt.jl")
 
+# avoid type piracy on Base.LineEdit.buffer
+buffer(io::IOBuffer) = io
+buffer(x) = Base.LineEdit.buffer(x)
+
 # Some backward compatability
 module ANSICodes
     using Crayons

--- a/src/repl.jl
+++ b/src/repl.jl
@@ -5,8 +5,8 @@ module Prompt
 
 import Base: LineEdit, REPL
 
-import Base.LineEdit: buffer, cmove_col, cmove_up, InputAreaState, transition,
-                      terminal, buffer, on_enter, move_input_end, add_history, state, mode, edit_insert
+import Base.LineEdit: cmove_col, cmove_up, InputAreaState, transition,
+                      terminal, on_enter, move_input_end, add_history, state, mode, edit_insert
 import Base.REPL: respond, LatexCompletions, return_callback
 
 import Tokenize.Lexers
@@ -16,7 +16,7 @@ import Base.Terminals: raw!, width, height, cmove, getX,
                        getY, clear_line, beep, disable_bracketed_paste, enable_bracketed_paste
 
 using OhMyREPL
-import OhMyREPL: untokenize_with_ANSI, apply_passes!, PASS_HANDLER
+import OhMyREPL: untokenize_with_ANSI, apply_passes!, PASS_HANDLER, buffer
 
 
 function rewrite_with_ANSI(s, cursormove::Bool = false)
@@ -64,8 +64,6 @@ function rewrite_with_ANSI(s, cursormove::Bool = false)
         flush(terminal(s))
 end
 
-
-buffer(io::IOBuffer) = io
 
 function create_keybindings()
 


### PR DESCRIPTION
by defining a package local method