### PR TITLE
Show any unexpected stderr output during __init__

### DIFF
--- a/src/OhMyREPL.jl
+++ b/src/OhMyREPL.jl
@@ -121,13 +121,20 @@ function __init__()
         end
     end
 
-    mktemp() do _, f
+    mktemp() do file, io
         old_stderr = STDERR
-        redirect_stderr(f)
+        redirect_stderr(io)
         Base.LineEdit.refresh_line(s) = (Base.LineEdit.refresh_multi_line(s); OhMyREPL.Prompt.rewrite_with_ANSI(s))
         include(joinpath(@__DIR__, "output_prompt_overwrite.jl"))
         include(joinpath(@__DIR__, "MarkdownHighlighter.jl"))
         redirect_stderr(old_stderr)
+        close(io)
+        for line in eachline(file)
+            if !ismatch(Regex("^WARNING: Method definition [refresh_line|display|term]" *
+                    ".* overwritten in module .* at $(@__DIR__).*\$"), line)
+                println(line)
+            end
+        end
     end
 end
 

--- a/src/OhMyREPL.jl
+++ b/src/OhMyREPL.jl
@@ -128,10 +128,10 @@ function __init__()
         include(joinpath(@__DIR__, "output_prompt_overwrite.jl"))
         include(joinpath(@__DIR__, "MarkdownHighlighter.jl"))
         redirect_stderr(old_stderr)
-        close(io)
-        for line in eachline(file)
+        seek(io, 0)
+        for line in eachline(io)
             if !ismatch(Regex("^WARNING: Method definition [refresh_line|display|term]" *
-                    ".* overwritten in module .* at $(@__DIR__).*\$"), line)
+                    ".* overwritten in module .* at $(escape_string(@__DIR__)).*\$"), line)
                 println(line)
             end
         end


### PR DESCRIPTION
Should be somewhat less error-prone, to only hide exactly the expected warnings instead of every possible problem that might be going to stderr at load time.