### PR TITLE
add colorscheme: Distinguished

### DIFF
--- a/src/passes/SyntaxHighlighter.jl
+++ b/src/passes/SyntaxHighlighter.jl
@@ -88,6 +88,7 @@ add!(SYNTAX_HIGHLIGHTER_SETTINGS, "TomorrowNightBright", _create_tomorrow_night_
 add!(SYNTAX_HIGHLIGHTER_SETTINGS, "TomorrowNightBright24bit", _create_tomorrow_night_bright_24())
 add!(SYNTAX_HIGHLIGHTER_SETTINGS, "Tomorrow24bit", _create_tomorrow_24())
 add!(SYNTAX_HIGHLIGHTER_SETTINGS, "Tomorrow", _create_tomorrow_256())
+add!(SYNTAX_HIGHLIGHTER_SETTINGS, "Distinguished", _create_distinguished())
 
 # Added by default
 # add!(SYNTAX_HIGHLIGHTER_SETTINGS, "JuliaDefault", _create_juliadefault())

--- a/src/passes/colorschemes.jl
+++ b/src/passes/colorschemes.jl
@@ -154,3 +154,20 @@ function _create_tomorrow_256()
     number!(cs, Crayon(foreground = 208))
     return cs
 end
+
+function _create_distinguished()
+    cs = ColorScheme()
+    symbol!(cs, Crayon(foreground = 66, bold=true))
+    comment!(cs, Crayon(foreground = 243))
+    string!(cs, Crayon(foreground = 143))
+    call!(cs, Crayon(foreground = :default))
+    op!(cs, Crayon(foreground = 180))
+    keyword!(cs, Crayon(foreground = 173))
+    text!(cs, Crayon(foreground = :default))
+    macro!(cs, Crayon(foreground = 247))
+    function_def!(cs, Crayon(foreground = :default))
+    error!(cs, Crayon(foreground = :default))
+    argdef!(cs, Crayon(foreground = 67))
+    number!(cs, Crayon(foreground = 173))
+    return cs
+end


### PR DESCRIPTION
I use this colorscheme in VIM. Its still very different in subtle ways (like $myvar interpolation and such), but it looks pretty close.

<img width="1038" alt="screen shot 2017-10-08 at 11 18 56" src="https://user-images.githubusercontent.com/10854026/31315537-0134063c-ac1b-11e7-8b0a-0a452a4e9e30.png">
