### PR TITLE
Always load if Julia is started with -i -e

### DIFF
--- a/src/OhMyREPL.jl
+++ b/src/OhMyREPL.jl
@@ -87,7 +87,7 @@ showpasses(io::IO = STDOUT) = Base.show(io, PASS_HANDLER)
 function __init__()
     options = Base.JLOptions()
     # command-line
-    if (options.eval != C_NULL) || (options.print != C_NULL)
+    if (options.isinteractive != 1) && ((options.eval != C_NULL) || (options.print != C_NULL))
         return
     end
 


### PR DESCRIPTION
This makes more sense to me than the current behaviour, which totally prevents loading when Julia is started with `julia -i -e "blah"`. The other possible option I see is to force loading OhMyREPL via an environment variable or providing an API to init it, but those seem more cumbersome than this change.