### PR TITLE
markdown fixes

### DIFF
--- a/src/MarkdownHighlighter.jl
+++ b/src/MarkdownHighlighter.jl
@@ -39,7 +39,7 @@ function Base.Markdown.term(io::IO, md::Base.Markdown.Code, columns)
             SYNTAX_HIGHLIGHTER_SETTINGS(crayons, tokens, 0)
             buff = IOBuffer()
             if lang == "jldoctest" || lang == "julia-repl"
-                print(buff, Crayon(foreground = :yellow, bold = true), "julia> ", Crayon(reset = true))
+                print(buff, Crayon(foreground = :red, bold = true), "julia> ", Crayon(reset = true))
             end
             for (token, crayon) in zip(tokens, crayons)
                 print(buff, crayon)

--- a/src/MarkdownHighlighter.jl
+++ b/src/MarkdownHighlighter.jl
@@ -3,9 +3,7 @@ using Crayons
 using Tokenize
 
 import OhMyREPL.Passes.SyntaxHighlighter.SYNTAX_HIGHLIGHTER_SETTINGS
-
-HIGHLIGHT_MARKDOWN = Ref(true)
-enable_highlight_markdown(v::Bool) = HIGHLIGHT_MARKDOWN[] = v
+import OhMyREPL.HIGHLIGHT_MARKDOWN
 
 function Base.Markdown.term(io::IO, md::Base.Markdown.Code, columns)
     code = md.code

--- a/src/OhMyREPL.jl
+++ b/src/OhMyREPL.jl
@@ -84,6 +84,9 @@ end
 showpasses(io::IO = STDOUT) = Base.show(io, PASS_HANDLER)
 
 
+const HIGHLIGHT_MARKDOWN = Ref(true)
+enable_highlight_markdown(v::Bool) = HIGHLIGHT_MARKDOWN[] = v
+
 function __init__()
     options = Base.JLOptions()
     # command-line


### PR DESCRIPTION
* fix enable_highlight_markdown to work, fixes #110 
* changes the julia prompt in doctests to red to better work with light backgrounds

cc @goerz, do you still believe a setting for the markdown prompt color is needed, now when red is the default?