### PR TITLE
Cap Documenter to v0.19

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,4 @@ notifications:
 script:
   - julia -e 'import Pkg; Pkg.build(); Pkg.test(; coverage=true)'
 after_success:
-  - julia -e 'Pkg.add("Documenter"); include(joinpath("docs", "make.jl"))'
+  - julia -e 'using Pkg; ps=PackageSpec(name="Documenter", version="0.19"); Pkg.add(ps); Pkg.pin(ps); include(joinpath("docs", "make.jl"))'


### PR DESCRIPTION
Due to upcoming breaking changes in Documenter. This make sure that the doc builds do not start failing when 0.20 lands in METADATA. [See this thread on Discourse for more information.](https://discourse.julialang.org/t/psa-documenter-jl-breaking-changes-version-capping/16431) 

Ref: JuliaDocs/Documenter.jl#861