### PR TITLE
fix coloring of a:b

### DIFF
--- a/src/passes/SyntaxHighlighter.jl
+++ b/src/passes/SyntaxHighlighter.jl
@@ -110,7 +110,8 @@ function (highlighter::SyntaxHighlighterSettings)(crayons::Vector{Crayon}, token
             crayons[i-1] = cscheme.argdef
             crayons[i] = cscheme.argdef
         # :foo
-        elseif kind(t) == Tokens.IDENTIFIER && exactkind(prev_t) == Tokens.COLON
+        elseif kind(t) == Tokens.IDENTIFIER && exactkind(prev_t) == Tokens.COLON && 
+               kind(pprev_t) ∉ (Tokens.INTEGER, Tokens.FLOAT, Tokens.IDENTIFIER, Tokens.RPAREN)
             crayons[i-1] = cscheme.symbol
             crayons[i] = cscheme.symbol
         # function


### PR DESCRIPTION
fixes coloring of `1:b`, `1.0:b`, `(1+2):b`, `a:b` (#181)
but not `1 :b`