### PR TITLE
Add Base16 Material Darker color scheme

### DIFF
--- a/docs/src/features/syntax_highlighting.md
+++ b/docs/src/features/syntax_highlighting.md
@@ -16,6 +16,7 @@ The current default colorschemes that comes with `OhMyREPL` are
 * "TomorrowNightBright" - 256 colors Tomorrow Night Bright
 * "TomorrowNightBright24bit" - 24 bit colored Tomorrow Night Bright
 * "OneDark" - 24 bit colored OneDark
+* "Base16MaterialDarker" - 24-bit [Base16](https://github.com/chriskempson/base16) Material Darker color scheme by [Nate Peters](https://github.com/ntpeters/base16-materialtheme-scheme)
 
  By default, "Monokai16" will be used on Windows and "Monokai256" otherwise. To test the supported colors in your terminal you can use `Crayons.test_system_colors()`, `Crayons.test_256_colors()`, `Crayons.test_24bit_colors()` to test 16, 256 and 24 bit colors respectively.
 

--- a/src/passes/SyntaxHighlighter.jl
+++ b/src/passes/SyntaxHighlighter.jl
@@ -89,6 +89,7 @@ add!(SYNTAX_HIGHLIGHTER_SETTINGS, "Tomorrow24bit", _create_tomorrow_24())
 add!(SYNTAX_HIGHLIGHTER_SETTINGS, "Tomorrow", _create_tomorrow_256())
 add!(SYNTAX_HIGHLIGHTER_SETTINGS, "Distinguished", _create_distinguished())
 add!(SYNTAX_HIGHLIGHTER_SETTINGS, "OneDark", _create_onedark())
+add!(SYNTAX_HIGHLIGHTER_SETTINGS, "Base16MaterialDarker", _create_base16_material_darker())
 # Added by default
 # add!(SYNTAX_HIGHLIGHTER_SETTINGS, "JuliaDefault", _create_juliadefault())
 

--- a/src/passes/colorschemes.jl
+++ b/src/passes/colorschemes.jl
@@ -188,3 +188,20 @@ function _create_onedark()
     number!(cs, Crayon(foreground = (209,154,102)))
     return cs
 end
+
+function _create_base16_material_darker()
+    cs = ColorScheme()
+    symbol!(cs, Crayon(foreground = 0xf07178))
+    comment!(cs, Crayon(foreground = 0x4a4a4a))
+    string!(cs, Crayon(foreground = 0xc3e88d))
+    call!(cs, Crayon(foreground = 0x82aaff))
+    op!(cs, Crayon(foreground = 0x89ddff))
+    keyword!(cs, Crayon(foreground = 0xc792ea))
+    text!(cs, Crayon(foreground = :default))
+    macro!(cs, Crayon(foreground = 0x82aaff))
+    function_def!(cs, Crayon(foreground = 0x82aaff))
+    error!(cs, Crayon(foreground = :default))
+    argdef!(cs, Crayon(foreground = 0xffcb6b))
+    number!(cs, Crayon(foreground = 0xf78c6c))
+    return cs
+end


### PR DESCRIPTION
Adds the Material Darker color scheme by [Nate Peters](https://github.com/ntpeters/base16-materialtheme-scheme) derived from the [Base16](https://github.com/chriskempson/base16) theme architecture.

Added under the name `"Base16MaterialDarker"`.