### PR TITLE
fixing transpose expressions

### DIFF
--- a/src/BracketInserter.jl
+++ b/src/BracketInserter.jl
@@ -33,6 +33,14 @@ function peek(b::IOBuffer)
     return c
 end
 
+# when we should not close the bracket
+function no_closing_bracket(left_peek, v)
+    # left_peek == v: we already have an open quote immediately before (triple quote)
+    # regex is for transposing calls: issue #200
+    # regex: immediately after letter/_: \w or closing array bracket \]
+    left_peek == v || (v == '\'' && occursin(r"\w|\]", string(left_peek)))
+end
+
 const AUTOMATIC_BRACKET_MATCH = Ref(!Sys.iswindows())
 enable_autocomplete_brackets(v::Bool) = AUTOMATIC_BRACKET_MATCH[] = v
 
@@ -105,8 +113,7 @@ function insert_into_keymap!(D::Dict)
                 # Next char is the quote symbol so just move right
                 if !eof(b) && peek(b) == v
                     edit_move_right(b)
-                # we already have an open quote immediately before (triple quote)
-                elseif position(b) > 0 && leftpeek(b) == v
+                elseif position(b) > 0 && no_closing_bracket(leftpeek(b), v)
                     edit_insert(b, v)
                 else
                     edit_insert(b, v)

--- a/src/BracketInserter.jl
+++ b/src/BracketInserter.jl
@@ -36,9 +36,9 @@ end
 # when we should not close the bracket
 function no_closing_bracket(left_peek, v)
     # left_peek == v: we already have an open quote immediately before (triple quote)
-    # regex is for transposing calls: issue #200
-    # regex: immediately after letter/_: \w or closing array bracket \]
-    left_peek == v || (v == '\'' && occursin(r"\w|\]", string(left_peek)))
+    # tr_expr is for transposing calls: issue #200
+    tr_expr = isletter(left_peek) || isnumeric(left_peek) || left_peek == '_' || left_peek == ']'
+    left_peek == v || (v == '\'' && tr_expr)
 end
 
 const AUTOMATIC_BRACKET_MATCH = Ref(!Sys.iswindows())


### PR DESCRIPTION
Potential fix for #200. Added condition such that transposing expressions `foo'`,  `foo_'` or `[1 2 3]'` does not autocomplete the `'`.

The bracket around `v == '\'' && occursin(r"\w|\]", string(left_peek))` is more for readability, not really needed due to operator precedence, feel free to change/remove.