### PR TITLE
Confirm on exit

### DIFF
--- a/src/repl.jl
+++ b/src/repl.jl
@@ -112,8 +112,7 @@ function create_keybindings()
         if buffer(s).size > 0
             LineEdit.edit_delete(buffer(s)); rewrite_with_ANSI(s)
         else
-            println(terminal(s))
-            return :abort
+            LineEdit.edit_abort(s)
         end
     end
 


### PR DESCRIPTION
Closes #137.

This should also future-proof OhMyREPL against future changes to the abort behaviour of the standard REPL. :relaxed: 