### PR TITLE
update Fzf for windows experience

### DIFF
--- a/docs/src/features/fzf.md
+++ b/docs/src/features/fzf.md
@@ -2,7 +2,7 @@
 
 ![](fzf.png)
 
-By default (on Julia 1.3+ and non-Windows installations), OhMyREPL will use
+By default (on Julia 1.3+), OhMyREPL will use
 [fzf](https://github.com/junegunn/fzf) to search in the REPL history (initiated
 by pressing Ctrl-R). This is a [fuzzy
 searcher](https://en.wikipedia.org/wiki/Approximate_string_matching) which means

--- a/src/OhMyREPL.jl
+++ b/src/OhMyREPL.jl
@@ -82,7 +82,7 @@ showpasses(io::IO = stdout) = Base.show(io, PASS_HANDLER)
 const HIGHLIGHT_MARKDOWN = Ref(true)
 enable_highlight_markdown(v::Bool) = HIGHLIGHT_MARKDOWN[] = v
 
-const ENABLE_FZF = Ref(!Sys.iswindows())
+const ENABLE_FZF = Ref(true)
 enable_fzf(v::Bool) = ENABLE_FZF[] = v
 
 function __init__()

--- a/src/repl.jl
+++ b/src/repl.jl
@@ -253,7 +253,7 @@ function create_keybindings()
     D["^R"] = function (s, data, c)
         if VERSION >= v"1.3" && OhMyREPL.ENABLE_FZF[]
             JLFzf = OhMyREPL.JLFzf
-            line = JLFzf.inter_fzf(JLFzf.read_repl_hist(), "--read0", "--tiebreak=index");
+            line = JLFzf.inter_fzf(JLFzf.read_repl_hist(), "--read0", "--tiebreak=index", "--height=80%");
             JLFzf.insert_history_to_repl(s, line)
             rewrite_with_ANSI(s)
         else


### PR DESCRIPTION
Reason probably is that if you do full screen windows terminal would clear the buffer.