### PR TITLE
possible fix for #239

### DIFF
--- a/src/repl.jl
+++ b/src/repl.jl
@@ -82,7 +82,8 @@ function create_keybindings()
     else
         beep(terminal(s))
     end
-    D["*"]    = (s, data, c) ->  (LineEdit.edit_insert(buffer(s), c); rewrite_with_ANSI(s))
+    D["*"]    = (s, data, c) -> (LineEdit.edit_insert(buffer(s), c); rewrite_with_ANSI(s))
+    D["^V"]   = (s, data, c) -> (LineEdit.edit_insert(buffer(s), REPL.InteractiveUtils.clipboard()); rewrite_with_ANSI(s))
     D["^B"]   = (s, data, c) -> (LineEdit.edit_move_left(buffer(s)) ;rewrite_with_ANSI(s))
     D["^F"]   = (s, data, c) -> (LineEdit.edit_move_right(buffer(s)) ;rewrite_with_ANSI(s))
     # Meta B


### PR DESCRIPTION
adds a keybind (ctrl-V but we could change) to paste directly

by using `InteractiveUtils.clipboard()`

allows nearly instant paste in julia 1.5 and it feels truly instant in julia 1.6

doesn't work in WSL (need to install xsel or xclip)

This is a quick fix I did when I discovered `clipboard()` today, I don't know much about it, feel free to do it differently

It might also allow to re-enable `enable_autocomplete_brackets` which was disabled due to #113 