### PR TITLE
use GarishPrint

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "julia.environmentPath": "/home/roger/code/julia/OhMyREPL"
+}

--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ version = "0.5.7"
 
 [deps]
 Crayons = "a8cc5b0e-0ffa-5ad4-8c14-923d3ee1735f"
+GarishPrint = "b0ab02a7-8576-43f7-aa76-eaa7c3897c54"
 JLFzf = "1019f520-868f-41f5-a6de-eb00f4b6a39c"
 Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
@@ -13,8 +14,8 @@ Tokenize = "0796e94c-ce3b-5d07-9a54-7f471281c624"
 
 [compat]
 Crayons = "1, 2, 3, 4"
-Tokenize = "0.5"
 JLFzf = "^0.1.1"
+Tokenize = "0.5"
 julia = "1.0"
 
 [extras]

--- a/src/OhMyREPL.jl
+++ b/src/OhMyREPL.jl
@@ -129,6 +129,7 @@ function __init__()
         include(joinpath(@__DIR__, "refresh_lines.jl"))
         include(joinpath(@__DIR__, "output_prompt_overwrite.jl"))
         include(joinpath(@__DIR__, "MarkdownHighlighter.jl"))
+        include(joinpath(@__DIR__, "output_show_overwrite.jl"))
     end
 end
 

--- a/src/OhMyREPL.jl
+++ b/src/OhMyREPL.jl
@@ -7,6 +7,8 @@ module OhMyREPL
 
 using Tokenize
 using Crayons
+using GarishPrint
+
 if VERSION > v"1.3"
 import JLFzf
 end

--- a/src/output_prompt_overwrite.jl
+++ b/src/output_prompt_overwrite.jl
@@ -5,6 +5,11 @@ function REPL.display(d::REPL.REPLDisplay, mime::MIME"text/plain", x)
     write(io, OUTPUT_PROMPT_PREFIX)
     write(io, output_prompt, "\e[0m")
     Base.have_color && write(io, REPL.answer_color(d.repl))
-    show(IOContext(io, :limit => true), mime, x)
+    limited_io = IOContext(io, :limit => true)
+    if hasmethod(Base.show, Tuple{typeof(limited_io), MIME"text/plain", typeof(x)})
+        show(limited_io, mime, x)
+    else
+        pprint(limited_io, mime, x)
+    end
     println(io)
 end

--- a/src/output_show_overwrite.jl
+++ b/src/output_show_overwrite.jl
@@ -1,0 +1,3 @@
+using GarishPrint
+
+Base.show(io::IO, ::MIME"text/plain", x) = pprint(io, x)


### PR DESCRIPTION
This is a draft PR since the package GarishPrint still has one day until registered.

I can't think of if there is a non-hacking of doing this, since I'm not sure how to make the display get dispatched to `pprint` instead of `Base.show` if `Base.show` is not overloaded for a given object, because we don't have a reflection mechanism of detecting that IIUC.

so I just replace the default REPL multi-line print with `Base.show(io::IO, ::MIME"text/plain", x)`, I think under the context of OhMyREPL this is probably fine.

check the effect

![image](https://user-images.githubusercontent.com/8445510/123042569-07ee2e00-d3c5-11eb-92ce-85c39003ebbf.png)

The color scheme is not consistent with OhMyREPL and doesn't support changing theme in this PR yet, but GarishPrint supports changing color preference, I need to read up how OhMyREPL store the color themes first.