### PR TITLE
default to 256 color with julia1.5.3 and later on windows

### DIFF
--- a/src/OhMyREPL.jl
+++ b/src/OhMyREPL.jl
@@ -15,7 +15,7 @@ import REPL
 
 export colorscheme!, colorschemes, enable_autocomplete_brackets, enable_highlight_markdown, enable_fzf, test_colorscheme
 
-const Supports256colors = !(Sys.iswindows() && VERSION < v"1.5.3")
+const SUPPORTS_256_COLORS = !(Sys.iswindows() && VERSION < v"1.5.3")
 
 include("repl_pass.jl")
 include("repl.jl")

--- a/src/OhMyREPL.jl
+++ b/src/OhMyREPL.jl
@@ -15,6 +15,8 @@ import REPL
 
 export colorscheme!, colorschemes, enable_autocomplete_brackets, enable_highlight_markdown, enable_fzf, test_colorscheme
 
+const Supports256colors = !(Sys.iswindows() && VERSION < v"1.5.3")
+
 include("repl_pass.jl")
 include("repl.jl")
 include("passes/Passes.jl")

--- a/src/passes/RainbowBrackets.jl
+++ b/src/passes/RainbowBrackets.jl
@@ -50,7 +50,7 @@ const RAINBOW_TOKENS_256 =
                           Crayon(foreground = 196, bold = true))
 
 const RAINBOWBRACKETS_SETTINGS = RainbowBracketsSettings(RAINBOW_TOKENS_256, RAINBOW_TOKENS_16,
-    Supports256colors ? RAINBOW_TOKENS_256 : RAINBOW_TOKENS_16)
+        SUPPORTS_256_COLORS ? RAINBOW_TOKENS_256 : RAINBOW_TOKENS_16)
 
 
 function (rainbow::RainbowBracketsSettings)(ansitokens::Vector{Crayon}, tokens::Vector{Token}, cursorpos::Int)

--- a/src/passes/RainbowBrackets.jl
+++ b/src/passes/RainbowBrackets.jl
@@ -5,7 +5,7 @@ using Tokenize
 using Tokenize.Tokens
 import Tokenize.Tokens: Token, kind, startpos, endpos, untokenize
 
-import OhMyREPL: add_pass!, PASS_HANDLER, Supports256colors
+import OhMyREPL: add_pass!, PASS_HANDLER, SUPPORTS_256_COLORS
 
 mutable struct RainBowTokens
     parenthesis_tokens::Vector{Crayon}

--- a/src/passes/RainbowBrackets.jl
+++ b/src/passes/RainbowBrackets.jl
@@ -5,7 +5,7 @@ using Tokenize
 using Tokenize.Tokens
 import Tokenize.Tokens: Token, kind, startpos, endpos, untokenize
 
-import OhMyREPL: add_pass!, PASS_HANDLER
+import OhMyREPL: add_pass!, PASS_HANDLER, Supports256colors
 
 mutable struct RainBowTokens
     parenthesis_tokens::Vector{Crayon}
@@ -49,7 +49,8 @@ const RAINBOW_TOKENS_256 =
                          [Crayon(foreground = 223), Crayon(foreground = 130), Crayon(foreground = 202)],
                           Crayon(foreground = 196, bold = true))
 
-const RAINBOWBRACKETS_SETTINGS = RainbowBracketsSettings(RAINBOW_TOKENS_256, RAINBOW_TOKENS_16, Sys.iswindows() ? RAINBOW_TOKENS_16 : RAINBOW_TOKENS_256)
+const RAINBOWBRACKETS_SETTINGS = RainbowBracketsSettings(RAINBOW_TOKENS_256, RAINBOW_TOKENS_16,
+    Supports256colors ? RAINBOW_TOKENS_256 : RAINBOW_TOKENS_16)
 
 
 function (rainbow::RainbowBracketsSettings)(ansitokens::Vector{Crayon}, tokens::Vector{Token}, cursorpos::Int)

--- a/src/passes/SyntaxHighlighter.jl
+++ b/src/passes/SyntaxHighlighter.jl
@@ -6,7 +6,7 @@ import Tokenize.Tokens: Token, kind, exactkind, iskeyword, untokenize
 
 using Crayons
 
-import OhMyREPL: add_pass!, PASS_HANDLER
+import OhMyREPL: add_pass!, PASS_HANDLER, Supports256colors
 
 mutable struct ColorScheme
     symbol::Crayon
@@ -94,7 +94,7 @@ add!(SYNTAX_HIGHLIGHTER_SETTINGS, "GruvboxDark", _create_gruvbox_dark())
 # Added by default
 # add!(SYNTAX_HIGHLIGHTER_SETTINGS, "JuliaDefault", _create_juliadefault())
 
-if !Sys.iswindows()
+if Supports256colors
     activate!(SYNTAX_HIGHLIGHTER_SETTINGS, "Monokai256")
 else
     activate!(SYNTAX_HIGHLIGHTER_SETTINGS, "Monokai16")

--- a/src/passes/SyntaxHighlighter.jl
+++ b/src/passes/SyntaxHighlighter.jl
@@ -94,7 +94,7 @@ add!(SYNTAX_HIGHLIGHTER_SETTINGS, "GruvboxDark", _create_gruvbox_dark())
 # Added by default
 # add!(SYNTAX_HIGHLIGHTER_SETTINGS, "JuliaDefault", _create_juliadefault())
 
-if Supports256colors
+if SUPPORTS_256_COLORS
     activate!(SYNTAX_HIGHLIGHTER_SETTINGS, "Monokai256")
 else
     activate!(SYNTAX_HIGHLIGHTER_SETTINGS, "Monokai16")

--- a/src/passes/SyntaxHighlighter.jl
+++ b/src/passes/SyntaxHighlighter.jl
@@ -6,7 +6,7 @@ import Tokenize.Tokens: Token, kind, exactkind, iskeyword, untokenize
 
 using Crayons
 
-import OhMyREPL: add_pass!, PASS_HANDLER, Supports256colors
+import OhMyREPL: add_pass!, PASS_HANDLER, SUPPORTS_256_COLORS 
 
 mutable struct ColorScheme
     symbol::Crayon


### PR DESCRIPTION
a more thorough check would be better but I guess this would be the job of Crayons.jl (ref https://github.com/KristofferC/Crayons.jl/issues/15)

based on my testing, support is here starting from julia 1.5.3, even though it only appears in the [1.6 NEWS](https://github.com/JuliaLang/julia/blob/v1.6.0-beta1/NEWS.md?plain=1#L237) (PR is not linked, I don't know where exactly it was fixed)