### PR TITLE
Markdown highlighting: Make prompt configurable

### DIFF
--- a/src/MarkdownHighlighter.jl
+++ b/src/MarkdownHighlighter.jl
@@ -1,4 +1,3 @@
-
 using Crayons
 using Tokenize
 import Markdown
@@ -43,7 +42,7 @@ function Markdown.term(io::IO, md::Markdown.Code, columns)
             SYNTAX_HIGHLIGHTER_SETTINGS(crayons, tokens, 0)
             buff = IOBuffer()
             if lang == "jldoctest" || lang == "julia-repl"
-                print(buff, Crayon(foreground = :red, bold = true), "julia> ", Crayon(reset = true))
+                print(buff, MARKDOWN_PROMPT, Crayon(reset = true))
             end
             for (token, crayon) in zip(tokens, crayons)
                 print(buff, crayon)
@@ -67,3 +66,10 @@ function Markdown.term(io::IO, md::Markdown.Code, columns)
         end
     end
 end
+
+function markdown_prompt!(prompt::Union{String, Function} = "julia> "; crayon::Crayon = Crayon(foreground = :red, bold = true))
+    global MARKDOWN_PROMPT = sprint(print, crayon, prompt)
+    return
+end
+
+markdown_prompt!()


### PR DESCRIPTION
As it seems from #100, #101 and #272 different people want different prompts in their markdown code highlighting. So this PR provides just that in the form of `markdown_prompt!(prompt; crayon)` for configuration.

Is that fine? If so, I can add a line to the docs as well.