### PR TITLE
change backspaces behave on active region

### DIFF
--- a/src/BracketInserter.jl
+++ b/src/BracketInserter.jl
@@ -11,8 +11,8 @@ end
 
 import REPL
 import REPL.LineEdit
-import REPL.LineEdit: edit_insert, edit_move_left, edit_move_right, buffer, char_move_left,
-                      edit_backspace, terminal, transition, state
+import REPL.LineEdit: edit_insert, edit_move_left, edit_move_right, edit_backspace, edit_kill_region,
+                      is_region_active, buffer, char_move_left,  terminal, transition, state
 
 import REPL.Terminals.beep
 import OhMyREPL.Prompt.rewrite_with_ANSI
@@ -133,7 +133,7 @@ function insert_into_keymap!(D::Dict)
     right_brackets2 = [')', '}', ']', '\"', '\'', '\`']
     D['\b'] = (s, data, c) -> begin
         repl = Base.active_repl
-        mirepl = isdefined(repl,:mi) ? repl.mi : repl
+        mirepl = isdefined(repl, :mi) ? repl.mi : repl
         main_mode = mirepl.interface.modes[1]
         if isempty(s) || position(buffer(s)) == 0
             buf = copy(buffer(s))
@@ -143,9 +143,9 @@ function insert_into_keymap!(D::Dict)
         else
             b = buffer(s)
             str = String(take!(copy(b)))
-            if AUTOMATIC_BRACKET_MATCH[] && !eof(buffer(s)) && position(buffer(s)) != nothing
+            if AUTOMATIC_BRACKET_MATCH[] && !eof(buffer(s)) && position(buffer(s)) !== nothing
                 i = findfirst(isequal(str[prevind(str, position(b) + 1)]), left_brackets2)
-                if i != nothing && peek(b) == right_brackets2[i]
+                if i !== nothing && peek(b) == right_brackets2[i]
                     edit_move_right(buffer(s))
                     edit_backspace(buffer(s))
                     edit_backspace(buffer(s))
@@ -153,7 +153,7 @@ function insert_into_keymap!(D::Dict)
                     return
                 end
             end
-            edit_backspace(s, true)
+            is_region_active(s) ? edit_kill_region(s) : edit_backspace(s, true)
         end
         rewrite_with_ANSI(s)
     end

--- a/src/BracketInserter.jl
+++ b/src/BracketInserter.jl
@@ -135,7 +135,9 @@ function insert_into_keymap!(D::Dict)
         repl = Base.active_repl
         mirepl = isdefined(repl, :mi) ? repl.mi : repl
         main_mode = mirepl.interface.modes[1]
-        if isempty(s) || position(buffer(s)) == 0
+        if is_region_active(s)
+            edit_kill_region(s)
+        elseif isempty(s) || position(buffer(s)) == 0
             buf = copy(buffer(s))
             transition(s, main_mode) do
                 state(s, main_mode).input_buffer = buf
@@ -153,7 +155,7 @@ function insert_into_keymap!(D::Dict)
                     return
                 end
             end
-            is_region_active(s) ? edit_kill_region(s) : edit_backspace(s, true)
+            edit_backspace(s, true)
         end
         rewrite_with_ANSI(s)
     end

--- a/src/passes/BracketHighlighter.jl
+++ b/src/passes/BracketHighlighter.jl
@@ -55,9 +55,9 @@ function bracket_match(tokens::Vector{Token}, cursoridx::Int)
     for idx in enclosing_token_idx:-1:0
         idx == 0 && return 0, 0, false
         token = tokens[idx]
-        (i = findfirst(isequal(kind(token)), RIGHT_DELIMS)) != nothing && (counts[i] -= 1)
+        (i = findfirst(isequal(kind(token)), RIGHT_DELIMS)) !== nothing && (counts[i] -= 1)
 
-        if (i = findfirst(isequal(kind(token)), LEFT_DELIMS)) != nothing
+        if (i = findfirst(isequal(kind(token)), LEFT_DELIMS)) !== nothing
             if counts[i] == 0
                 left_match = i
                 left_idx = idx


### PR DESCRIPTION
In REPL, backspace will delete active region.
I changed to make it behaves the same.
#283 