### PR TITLE
Add GitHub colorschemes

### DIFF
--- a/docs/src/features/syntax_highlighting.md
+++ b/docs/src/features/syntax_highlighting.md
@@ -18,6 +18,7 @@ The current default colorschemes that comes with `OhMyREPL` are
 * "OneDark" - 24 bit colored OneDark
 * "Base16MaterialDarker" - 24-bit [Base16](https://github.com/chriskempson/base16) Material Darker color scheme by [Nate Peters](https://github.com/ntpeters/base16-materialtheme-scheme)
 * "GruvboxDark" - Dark-mode variation of the [Gruvbox](https://github.com/morhetz/gruvbox#dark-mode) color scheme by Pavel Pertsev.
+* "GitHubLight", "GitHubDark" and "GitHubDarkDimmed" - GitHub's [color schemes](https://primer.style/primitives/colors#themes), matching the [VSCode Themes](https://github.com/primer/github-vscode-theme/)
 
  By default, "Monokai16" will be used on Windows and "Monokai256" otherwise. To test the supported colors in your terminal you can use `Crayons.test_system_colors()`, `Crayons.test_256_colors()`, `Crayons.test_24bit_colors()` to test 16, 256 and 24 bit colors respectively.
 

--- a/docs/src/features/syntax_highlighting.md
+++ b/docs/src/features/syntax_highlighting.md
@@ -18,7 +18,7 @@ The current default colorschemes that comes with `OhMyREPL` are
 * "OneDark" - 24 bit colored OneDark
 * "Base16MaterialDarker" - 24-bit [Base16](https://github.com/chriskempson/base16) Material Darker color scheme by [Nate Peters](https://github.com/ntpeters/base16-materialtheme-scheme)
 * "GruvboxDark" - Dark-mode variation of the [Gruvbox](https://github.com/morhetz/gruvbox#dark-mode) color scheme by Pavel Pertsev.
-* "GitHubLight", "GitHubDark" and "GitHubDarkDimmed" - GitHub's [color schemes](https://primer.style/primitives/colors#themes), matching the [VSCode Themes](https://github.com/primer/github-vscode-theme/)
+* "GitHubLight", "GitHubDark" and "GitHubDarkDimmed" - GitHub's [colorschemes](https://primer.style/primitives/colors#themes), matching the [VS Code themes](https://github.com/primer/github-vscode-theme/)
 
  By default, "Monokai16" will be used on Windows and "Monokai256" otherwise. To test the supported colors in your terminal you can use `Crayons.test_system_colors()`, `Crayons.test_256_colors()`, `Crayons.test_24bit_colors()` to test 16, 256 and 24 bit colors respectively.
 

--- a/src/passes/SyntaxHighlighter.jl
+++ b/src/passes/SyntaxHighlighter.jl
@@ -91,6 +91,9 @@ add!(SYNTAX_HIGHLIGHTER_SETTINGS, "Distinguished", _create_distinguished())
 add!(SYNTAX_HIGHLIGHTER_SETTINGS, "OneDark", _create_onedark())
 add!(SYNTAX_HIGHLIGHTER_SETTINGS, "Base16MaterialDarker", _create_base16_material_darker())
 add!(SYNTAX_HIGHLIGHTER_SETTINGS, "GruvboxDark", _create_gruvbox_dark())
+add!(SYNTAX_HIGHLIGHTER_SETTINGS, "GitHubLight", _create_github_light())
+add!(SYNTAX_HIGHLIGHTER_SETTINGS, "GitHubDark", _create_github_dark())
+add!(SYNTAX_HIGHLIGHTER_SETTINGS, "GitHubDarkDimmed", _create_github_dark_dimmed())
 # Added by default
 # add!(SYNTAX_HIGHLIGHTER_SETTINGS, "JuliaDefault", _create_juliadefault())
 

--- a/src/passes/colorschemes.jl
+++ b/src/passes/colorschemes.jl
@@ -220,3 +220,80 @@ function _create_gruvbox_dark() #palette https://github.com/morhetz/gruvbox#dark
     number!(cs, Crayon(foreground = 0xd3869b)) #purple
     return cs
 end
+
+function _create_github_light()
+    # https://primer.style/primitives/colors#themes
+    # Note: this matches "GitHub Light Default", not the legacy "GitHub Light"
+    blue = 0x0450ae
+    dark_blue = 0x0a2f69
+    gray = 0x6f7781
+    red = 0xce222e
+    purple = 0x8250df
+    black = 0x24292f
+
+    cs = ColorScheme()
+    symbol!(cs, Crayon(foreground = blue))
+    comment!(cs, Crayon(foreground = gray))
+    string!(cs, Crayon(foreground = dark_blue))
+    call!(cs, Crayon(foreground = blue))
+    op!(cs, Crayon(foreground = red))
+    keyword!(cs, Crayon(foreground = red))
+    text!(cs, Crayon(foreground = black))
+    macro!(cs, Crayon(foreground = blue))
+    function_def!(cs, Crayon(foreground = purple))
+    error!(cs, Crayon(foreground = :default))
+    argdef!(cs, Crayon(foreground = blue))
+    number!(cs, Crayon(foreground = blue))
+    return cs
+end
+
+function _create_github_dark()
+    # https://primer.style/primitives/colors#themes
+    # Note: this matches "GitHub Dark Default", not the legacy "GitHub Dark"
+    blue = 0x79c0ff
+    light_blue = 0xa4d7ff
+    gray = 0x8c949e
+    light_gray = 0xc9d1d9
+    red = 0xfe7b72
+    purple = 0xd2a8ff
+
+    cs = ColorScheme()
+    symbol!(cs, Crayon(foreground = blue))
+    comment!(cs, Crayon(foreground = gray))
+    string!(cs, Crayon(foreground = light_blue))
+    call!(cs, Crayon(foreground = blue))
+    op!(cs, Crayon(foreground = red))
+    keyword!(cs, Crayon(foreground = red))
+    text!(cs, Crayon(foreground = light_gray))
+    macro!(cs, Crayon(foreground = blue))
+    function_def!(cs, Crayon(foreground = purple))
+    error!(cs, Crayon(foreground = :default))
+    argdef!(cs, Crayon(foreground = blue))
+    number!(cs, Crayon(foreground = blue))
+    return cs
+end
+
+function _create_github_dark_dimmed()
+    # https://primer.style/primitives/colors#themes
+    blue = 0x6cb6ff
+    light_blue = 0x96d0ff
+    gray = 0x768390
+    light_gray = 0xadbac7
+    red = 0xf47067
+    purple = 0xdcbdfb
+
+    cs = ColorScheme()
+    symbol!(cs, Crayon(foreground = blue))
+    comment!(cs, Crayon(foreground = gray))
+    string!(cs, Crayon(foreground = light_blue))
+    call!(cs, Crayon(foreground = blue))
+    op!(cs, Crayon(foreground = red))
+    keyword!(cs, Crayon(foreground = red))
+    text!(cs, Crayon(foreground = light_gray))
+    macro!(cs, Crayon(foreground = blue))
+    function_def!(cs, Crayon(foreground = purple))
+    error!(cs, Crayon(foreground = :default))
+    argdef!(cs, Crayon(foreground = blue))
+    number!(cs, Crayon(foreground = blue))
+    return cs
+end


### PR DESCRIPTION
Adds three of GitHub's [colorschemes](https://primer.style/primitives/colors#themes), matching the [VS Code themes](https://github.com/primer/github-vscode-theme/):

## `"GitHubDark"`
<img width="1544" alt="GHDark" src="https://user-images.githubusercontent.com/20258504/212778640-b2b50e85-3065-496e-aa43-c6f9d29aa68f.png">

## `"GitHubDarkDimmed"`
<img width="1544" alt="GHDarkDimmed" src="https://user-images.githubusercontent.com/20258504/212778637-f5e3e38d-e531-4a41-98ec-7d2fa53a3bbb.png">

## `"GitHubLight"`
<img width="1544" alt="GHLight" src="https://user-images.githubusercontent.com/20258504/212778632-91b41cd9-3dbe-47dd-be14-867fcbabaf96.png">