### PR TITLE
added Dracula color scheme

### DIFF
--- a/src/passes/SyntaxHighlighter.jl
+++ b/src/passes/SyntaxHighlighter.jl
@@ -94,6 +94,7 @@ add!(SYNTAX_HIGHLIGHTER_SETTINGS, "GruvboxDark", _create_gruvbox_dark())
 add!(SYNTAX_HIGHLIGHTER_SETTINGS, "GitHubLight", _create_github_light())
 add!(SYNTAX_HIGHLIGHTER_SETTINGS, "GitHubDark", _create_github_dark())
 add!(SYNTAX_HIGHLIGHTER_SETTINGS, "GitHubDarkDimmed", _create_github_dark_dimmed())
+add!(SYNTAX_HIGHLIGHTER_SETTINGS, "Dracula", _create_dracula())
 # Added by default
 # add!(SYNTAX_HIGHLIGHTER_SETTINGS, "JuliaDefault", _create_juliadefault())
 

--- a/src/passes/colorschemes.jl
+++ b/src/passes/colorschemes.jl
@@ -297,3 +297,20 @@ function _create_github_dark_dimmed()
     number!(cs, Crayon(foreground = blue))
     return cs
 end
+
+function _create_dracula()
+    cs = ColorScheme()
+    symbol!(cs, Crayon(foreground = (255,184,108)))
+    comment!(cs, Crayon(foreground = (98, 114, 164)))
+    string!(cs, Crayon(foreground = (241, 250, 140)))
+    call!(cs, Crayon(foreground = (189, 147, 249)))
+    op!(cs, Crayon(foreground = (255, 121, 198)))
+    keyword!(cs, Crayon(foreground = (255, 121, 198)))
+    text!(cs, Crayon(foreground = (248, 248, 242)))
+    macro!(cs, Crayon(foreground = (80, 250, 123)))
+    function_def!(cs, Crayon(foreground = (189, 147, 249)))
+    error!(cs, Crayon(foreground = (255, 85, 85)))
+    argdef!(cs, Crayon(foreground = (139, 233, 253)))
+    number!(cs, Crayon(foreground = (255, 85, 85)))
+    return cs
+end


### PR DESCRIPTION
This is an updated version of a very old PR I had for adding this.  [Dracula](https://github.com/dracula/dracula-theme) is a popular color scheme implemented on a bewildering variety of software.  It would be great to have this in OhMyREPL so that I can finally take it out of my `startup.jl` :slightly_smiling_face: 