### PR TITLE
Use post-parse `JuliaSyntax.tokenize()` API

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -13,7 +13,7 @@ REPL = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 
 [compat]
 Crayons = "1, 2, 3, 4"
-JuliaSyntax = "0.3.0"
+JuliaSyntax = "0.3.3"
 JLFzf = "^0.1.1"
 julia = "1.6"
 

--- a/docs/Manifest.toml
+++ b/docs/Manifest.toml
@@ -73,9 +73,9 @@ uuid = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 version = "0.21.3"
 
 [[JuliaSyntax]]
-git-tree-sha1 = "db2bdeda30e452485863799be4515f6305431a46"
+git-tree-sha1 = "5f0b864db9e8d7c109eba0fe7d306a108fda5056"
 uuid = "70703baa-626e-46a2-a12c-08ffd08c73b4"
-version = "0.3.2"
+version = "0.3.3"
 
 [[LibCURL]]
 deps = ["LibCURL_jll", "MozillaCACerts_jll"]
@@ -109,14 +109,14 @@ uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
 [[MbedTLS_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "c8ffd9c3-330d-5841-b78e-0817d7145fa1"
-version = "2.28.2+0"
+version = "2.28.0+0"
 
 [[Mmap]]
 uuid = "a63ad114-7e13-5084-954f-fe012c677804"
 
 [[MozillaCACerts_jll]]
 uuid = "14a3606d-f60d-562e-9121-12d972cd8159"
-version = "2022.10.11"
+version = "2022.2.1"
 
 [[NetworkOptions]]
 uuid = "ca575930-c2e3-43a9-ace4-1e988b2c1908"
@@ -126,7 +126,7 @@ version = "1.2.0"
 deps = ["Crayons", "JLFzf", "JuliaSyntax", "Markdown", "Pkg", "Printf", "REPL"]
 path = ".."
 uuid = "5fb14364-9ced-5910-84b2-373655c76a03"
-version = "0.5.17"
+version = "0.5.18"
 
 [[Parsers]]
 deps = ["Dates", "SnoopPrecompile"]
@@ -140,9 +140,9 @@ uuid = "b98c9c47-44ae-5843-9183-064241ee97a0"
 version = "1.3.0"
 
 [[Pkg]]
-deps = ["Artifacts", "Dates", "Downloads", "FileWatching", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "Serialization", "TOML", "Tar", "UUIDs", "p7zip_jll"]
+deps = ["Artifacts", "Dates", "Downloads", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "Serialization", "TOML", "Tar", "UUIDs", "p7zip_jll"]
 uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
-version = "1.9.0"
+version = "1.8.0"
 
 [[Preferences]]
 deps = ["TOML"]
@@ -181,12 +181,12 @@ uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
 [[TOML]]
 deps = ["Dates"]
 uuid = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
-version = "1.0.3"
+version = "1.0.0"
 
 [[Tar]]
 deps = ["ArgTools", "SHA"]
 uuid = "a4e569a6-e804-4fa4-b0f3-eef7a1d5b13e"
-version = "1.10.0"
+version = "1.10.1"
 
 [[Test]]
 deps = ["InteractiveUtils", "Logging", "Random", "Serialization"]
@@ -202,7 +202,7 @@ uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
 [[Zlib_jll]]
 deps = ["Libdl"]
 uuid = "83775a58-1f1d-513f-b197-d71354ab007a"
-version = "1.2.13+0"
+version = "1.2.12+3"
 
 [[fzf_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]

--- a/src/MarkdownHighlighter.jl
+++ b/src/MarkdownHighlighter.jl
@@ -1,6 +1,5 @@
 
 using Crayons
-using JuliaSyntax.Tokenize
 import Markdown
 
 import .OhMyREPL.Passes.SyntaxHighlighter.SYNTAX_HIGHLIGHTER_SETTINGS

--- a/src/OhMyREPL.jl
+++ b/src/OhMyREPL.jl
@@ -6,7 +6,6 @@ bracket matching and other nifty features.
 module OhMyREPL
 
 import JuliaSyntax
-using JuliaSyntax.Tokenize
 using Crayons
 if VERSION > v"1.3"
 import JLFzf

--- a/src/passes/BracketHighlighter.jl
+++ b/src/passes/BracketHighlighter.jl
@@ -1,7 +1,6 @@
 module BracketHighlighter
 
-using JuliaSyntax.Tokenize
-import .Tokenize: Token, kind, startpos, untokenize
+using JuliaSyntax: kind, Token, untokenize
 
 using Crayons
 

--- a/src/passes/RainbowBrackets.jl
+++ b/src/passes/RainbowBrackets.jl
@@ -1,10 +1,7 @@
 module RainbowBrackets
 
 using Crayons
-import JuliaSyntax.@K_str
-import JuliaSyntax.Tokenize
-using .Tokenize
-import .Tokenize: Token, kind, startpos, untokenize, Kind
+import JuliaSyntax: kind, Kind, @K_str, Token
 
 import OhMyREPL: add_pass!, PASS_HANDLER, SUPPORTS_256_COLORS
 

--- a/src/passes/SyntaxHighlighter.jl
+++ b/src/passes/SyntaxHighlighter.jl
@@ -1,10 +1,7 @@
 module SyntaxHighlighter
 
 import JuliaSyntax
-import .JuliaSyntax.Tokenize
-import JuliaSyntax.@K_str
-using .Tokenize
-import .Tokenize: Token, kind, kind, untokenize
+using JuliaSyntax: @K_str, kind, Token, untokenize
 
 using Crayons
 
@@ -121,8 +118,10 @@ function (highlighter::SyntaxHighlighterSettings)(crayons::Vector{Crayon}, token
             crayons[i-1] = cscheme.argdef
             crayons[i] = cscheme.argdef
         =#
+        if JuliaSyntax.is_error(t)
+            crayons[i] = cscheme.error
         # :foo
-        if kind(t) == K"Identifier" && kind(prev_t) == K":" &&
+        elseif kind(t) == K"Identifier" && kind(prev_t) == K":" &&
                kind(pprev_t) ∉ (K"Integer", K"Float", K"Identifier", K")")
             crayons[i-1] = cscheme.symbol
             crayons[i] = cscheme.symbol

--- a/src/repl.jl
+++ b/src/repl.jl
@@ -11,8 +11,7 @@ import REPL: respond, return_callback
 import REPL.LineEdit: buffer, cmove_col, cmove_up, InputAreaState, transition,
                       terminal, buffer, on_enter, move_input_end, add_history, state, mode, edit_insert
 
-import JuliaSyntax.Tokenize
-import .Tokenize.Lexer
+import JuliaSyntax: tokenize, untokenize
 
 import REPL.Terminals: raw!, width, height, cmove, getX, TerminalBuffer,
                   getY, clear_line, beep, disable_bracketed_paste, enable_bracketed_paste
@@ -60,7 +59,7 @@ function rewrite_with_ANSI(s, cursormove::Bool = false)
         # Insert colorized text from running the passes
         seekstart(buffer(s))
         str = read(buffer(s), String)
-        tokens = collect(Lexer(str))
+        tokens = tokenize(str)
         apply_passes!(PASS_HANDLER, tokens, str, cursoridx, cursormove)
         untokenize_with_ANSI(outbuf, PASS_HANDLER, tokens, str)
 

--- a/src/repl_pass.jl
+++ b/src/repl_pass.jl
@@ -1,5 +1,5 @@
-import JuliaSyntax.Tokenize
-import .Tokenize: Token, kind, untokenize, Lexer
+import JuliaSyntax
+using JuliaSyntax: kind, @K_str, Token, tokenize, untokenize
 using Printf
 
 const RESET = Crayon(reset = true)
@@ -22,7 +22,7 @@ const PASS_HANDLER = PassHandler()
 function test_pass(io::IO, f, str::Union{String, IO}, cursorpos::Int = 1, cursormovement::Bool = false)
     rpc = PassHandler()
     add_pass!(rpc, "TestPass", f)
-    tokens = collect(Lexer(str))
+    tokens = tokenize(str)
     apply_passes!(rpc, tokens, str, cursorpos, cursormovement)
     untokenize_with_ANSI(io, rpc.accum_crayons, tokens, str)
 end
@@ -32,7 +32,7 @@ test_pass(f, str::Union{String, IOBuffer}, cursorpos::Int = 1, cursormovement::B
 
 function test_passes(io::IO, rpc::PassHandler, str::Union{String, IOBuffer}, cursorpos::Int = 1, cursormovement::Bool = false)
     b = IOBuffer()
-    tokens = collect(Lexer(str))
+    tokens = tokenize(str)
     apply_passes!(rpc, tokens, str, cursorpos, cursormovement)
     untokenize_with_ANSI(io, rpc.accum_crayons, tokens, str)
 end

--- a/test/test_custompass.jl
+++ b/test/test_custompass.jl
@@ -2,15 +2,14 @@ module CustomPassTest
 
 using Test
 using OhMyREPL
-import JuliaSyntax.Tokenize
-using .Tokenize
+using JuliaSyntax
+import JuliaSyntax: kind, untokenize, @K_str
 using Crayons
 
 function foobar_bluify(crayons, tokens, ::Int, str::AbstractString)
     for (i, (crayon, tok)) in enumerate(zip(crayons, tokens))
         println(tok)
-        if (Tokenize.kind(tok) == Tokenize.K"Identifier"
-               && Tokenize.untokenize(tok, str) == "foobar")
+        if (kind(tok) == K"Identifier" && untokenize(tok, str) == "foobar")
             crayons[i] = Crayon(foreground = :blue)
         end
     end

--- a/test/test_highlighter.jl
+++ b/test/test_highlighter.jl
@@ -5,9 +5,6 @@ using Test
 using OhMyREPL
 import  OhMyREPL.Passes.SyntaxHighlighter.SYNTAX_HIGHLIGHTER_SETTINGS
 
-import JuliaSyntax.Tokenize
-using .Tokenize
-
 OhMyREPL.colorscheme!("Monokai16")
 
 b = IOBuffer()


### PR DESCRIPTION
Going through the parser allows us to be more precise and complete.

For example it automatically:
* Determines when contextual keywords are keywords, vs identifiers. For example, the `outer` in `outer = 1` is an identifier, but a keyword in `for outer i = 1:10`
* Validates numeric literals (eg, detecting overflow cases like `10e1000` and flagging as errors)
* Splits or combines ambiguous tokens. For example, making the `...` in `import ...A` three separate `.` tokens.

Also uses `is_error` to detect error tokens and highlight them with the error color.

Requires https://github.com/JuliaLang/JuliaSyntax.jl/pull/221

As I was writing this, I noticed that the syntax highlighter has some heuristics in it to act a bit like a parser (just a very little bit!).  For example, highlighting quoted symbols a different color.

So I'm not sure this is the best approach long term - maybe we should just be using the parsed `GreenTree` instead for highlighting. It would give us several options for richer highlighting. Also, if using the parser itself, we'd be able to highlight any syntax error ranges (not just token errors).

Regardless of that, though, this is a straightforward modification we can do right away...

Screenshot showing `outer` and `abstract` contextual keywords highlighted correctly and some token errors
![asdf](https://user-images.githubusercontent.com/601473/225549600-20ab0e08-348f-44dd-9974-e5ae4639d915.png)
