### PR TITLE
Re-add typeassert highlighting

### DIFF
--- a/src/passes/SyntaxHighlighter.jl
+++ b/src/passes/SyntaxHighlighter.jl
@@ -112,14 +112,12 @@ function (highlighter::SyntaxHighlighterSettings)(crayons::Vector{Crayon}, token
     prev_t = Token()
     pprev_t = Token()
     for (i, t) in enumerate(tokens)
-        # a::x
-        #=
-        if kind(prev_t) == Tokens.DECLARATION
-            crayons[i-1] = cscheme.argdef
-            crayons[i] = cscheme.argdef
-        =#
         if JuliaSyntax.is_error(t)
             crayons[i] = cscheme.error
+        # a::x
+        elseif kind(t) == K"Identifier" && kind(prev_t) == K"::"
+            crayons[i-1] = cscheme.argdef
+            crayons[i] = cscheme.argdef
         # :foo
         elseif kind(t) == K"Identifier" && kind(prev_t) == K":" &&
                kind(pprev_t) ∉ (K"Integer", K"Float", K"Identifier", K")")


### PR DESCRIPTION
See issue #317.

I'm not sure how to test it rigorously, but it appears to work. It doesn't properly handle e.g. `x::Vector{Int}` as the `{Int}` part is not colored as part of the type. I guess the way to handle that would be to do a pre-processing pass over the tokens and collapse `{Int, UInt}` into a single "type token" as it was using Tokenizer.jl