### PR TITLE
return active colorscheme after `colorscheme!`

### DIFF
--- a/src/OhMyREPL.jl
+++ b/src/OhMyREPL.jl
@@ -31,6 +31,7 @@ function colorscheme!(name::String)
         Passes.SyntaxHighlighter.SYNTAX_HIGHLIGHTER_SETTINGS, name)
     Passes.RainbowBrackets.updatebracketcolors!(
         Passes.SyntaxHighlighter.SYNTAX_HIGHLIGHTER_SETTINGS.active)
+    return Passes.SyntaxHighlighter.SYNTAX_HIGHLIGHTER_SETTINGS.active
 end
 
 function colorschemes()


### PR DESCRIPTION
this was the case before #304

it breaks my `startup.jl`, where I modified the colorscheme using the returned value