### PR TITLE
Remove traling newline in Markdown code blocks

### DIFF
--- a/src/MarkdownHighlighter.jl
+++ b/src/MarkdownHighlighter.jl
@@ -36,7 +36,7 @@ function Markdown.term(io::IO, md::Markdown.Code, columns)
     end
 
     if do_syntax && HIGHLIGHT_MARKDOWN[]
-        for (sourcecode, output) in zip(sourcecodes, outputs)
+        for (i, (sourcecode, output)) in enumerate(zip(sourcecodes, outputs))
             tokens = collect(tokenize(sourcecode))
             crayons = fill(Crayon(), length(tokens))
             SYNTAX_HIGHLIGHTER_SETTINGS(crayons, tokens, 0, sourcecode)
@@ -52,16 +52,20 @@ function Markdown.term(io::IO, md::Markdown.Code, columns)
             print(buff, output)
 
             str = String(take!(buff))
-            for line in Markdown.lines(str)
-                print(io, " "^Markdown.margin)
-                println(io, line)
+            lines = Markdown.lines(str)
+            for li in eachindex(lines)
+                print(io, " "^Markdown.margin, lines[li])
+                li < lastindex(lines) && println(io)
             end
+
+            i < lastindex(sourcecodes) && println(io)
         end
     else
         Base.with_output_color(:cyan, io) do io
-            for line in Markdown.lines(md.code)
-                print(io, " "^Markdown.margin)
-                println(io, line)
+            lines = Markdown.lines(md.code)
+            for i in eachindex(lines)
+                print(io, " "^Markdown.margin, lines[i])
+                i < lastindex(lines) && println(io)
             end
         end
     end


### PR DESCRIPTION
This PR makes OhMyREPL match exactly [the default Markdown formatting of the stdlib](https://github.com/JuliaLang/julia/blob/1b183b93f4b78f567241b1e7511138798cea6a0d/stdlib/Markdown/src/render/terminal/render.jl#L105C1-L113C4) when `OhMyREPL.HIGHLIGHT_MARKDOWN[] == false`.

Formatted code in REPL help is then a bit more compact, with the downside that it might be a tad harder to make the difference between the output of a code example and text.

Before:
```julia
julia> using Markdown

julia> md"""
       A
       ```julia
       function a() end
       ```
       B
       """
  A

  function a() end

  B

julia> using OhMyREPL

julia> md"""
       A
       ```julia
       function a() end
       ```
       B
       """
  A

  function a() end


  B
```

After:
```julia
julia> using Markdown, OhMyREPL

julia> md"""
       A
       ```julia
       function a() end
       ```
       B
       """
  A

  function a() end

  B
```