### PR TITLE
Add ability to disable auto double quotes matching

### DIFF
--- a/src/BracketInserter.jl
+++ b/src/BracketInserter.jl
@@ -34,7 +34,9 @@ function no_closing_bracket(left_peek, v)
 end
 
 const AUTOMATIC_BRACKET_MATCH = Ref(!Sys.iswindows())
+const AUTOMATIC_STRING_LITERALS_MATCH = Ref(!Sys.iswindows()) # TODO: is the iswindows needed for this? And can we make the default be false for the Julia version(s) affected by #334?
 enable_autocomplete_brackets(v::Bool) = AUTOMATIC_BRACKET_MATCH[] = v
+enable_autocomplete_string_literals(v::Bool) = AUTOMATIC_STRING_LITERALS_MATCH[] = v
 
 const pkgmode = Ref{Any}()
 import Pkg
@@ -106,7 +108,7 @@ function insert_into_keymap!(D::Dict)
         D[v] = (s, o...) -> begin
             b = buffer(s)
 
-            if AUTOMATIC_BRACKET_MATCH[]
+            if (v == '\"' && AUTOMATIC_STRING_LITERALS_MATCH[]) || (v != '\"' && AUTOMATIC_BRACKET_MATCH[])
                 # Next char is the quote symbol so just move right
                 if !eof(b) && peek(b) == v
                     edit_move_right(b)

--- a/src/BracketInserter.jl
+++ b/src/BracketInserter.jl
@@ -34,7 +34,7 @@ function no_closing_bracket(left_peek, v)
 end
 
 const AUTOMATIC_BRACKET_MATCH = Ref(!Sys.iswindows())
-const AUTOMATIC_STRING_LITERALS_MATCH = Ref(!Sys.iswindows()) # TODO: is the iswindows needed for this? And can we make the default be false for the Julia version(s) affected by #334?
+const AUTOMATIC_STRING_LITERALS_MATCH = Ref(!Sys.iswindows() && !(VERSION >= v"1.10")) # TODO: is the iswindows needed for this? TODO: change default if a new Julia version makes this unnecessary
 enable_autocomplete_brackets(v::Bool) = AUTOMATIC_BRACKET_MATCH[] = v
 enable_autocomplete_string_literals(v::Bool) = AUTOMATIC_STRING_LITERALS_MATCH[] = v
 

--- a/src/BracketInserter.jl
+++ b/src/BracketInserter.jl
@@ -2,13 +2,6 @@ module BracketInserter
 
 using OhMyREPL
 
-# If a user writes an opening bracket
-# automatically complete it with a closing bracket
-# unless the next character is that closing bracket
-mutable struct BracketInserterSettings
-    complete_brackets::Bool
-end
-
 import REPL
 import REPL.LineEdit
 import REPL.LineEdit: edit_insert, edit_move_left, edit_move_right, edit_backspace, edit_kill_region,
@@ -17,7 +10,6 @@ import REPL.LineEdit: edit_insert, edit_move_left, edit_move_right, edit_backspa
 import REPL.Terminals.beep
 import OhMyREPL.Prompt.rewrite_with_ANSI
 
-const BRACKET_INSERTER = BracketInserterSettings(true)
 
 function leftpeek(b::IOBuffer)
     p = position(b)

--- a/src/OhMyREPL.jl
+++ b/src/OhMyREPL.jl
@@ -13,7 +13,7 @@ end
 
 import REPL
 
-export colorscheme!, colorschemes, enable_autocomplete_brackets, enable_highlight_markdown, enable_fzf, test_colorscheme
+export colorscheme!, colorschemes, enable_autocomplete_brackets, enable_autocomplete_string_literals, enable_highlight_markdown, enable_fzf, test_colorscheme
 
 const SUPPORTS_256_COLORS = !(Sys.iswindows() && VERSION < v"1.5.3")
 
@@ -25,6 +25,7 @@ include("BracketInserter.jl")
 include("prompt.jl")
 
 import .BracketInserter.enable_autocomplete_brackets
+import .BracketInserter.enable_autocomplete_string_literals
 
 function colorscheme!(name::String)
     Passes.SyntaxHighlighter.activate!(


### PR DESCRIPTION
This creates a workaround for #334. On Julia 1.10 and later the default is to disable OhMyREPL's matching of string literal delimiters (a.k.a double quotes `"`) , and this can be manually done on any Julia version with `enable_autocomplete_string_literals(false)`, which is exported as with the existing `enable_autocomplete_brackets`.