### PR TITLE
fix crash when repl.mistate is defined but nothing

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "OhMyREPL"
 uuid = "5fb14364-9ced-5910-84b2-373655c76a03"
-version = "0.5.25"
+version = "0.5.26"
 
 [deps]
 Crayons = "a8cc5b0e-0ffa-5ad4-8c14-923d3ee1735f"

--- a/src/repl.jl
+++ b/src/repl.jl
@@ -286,7 +286,7 @@ end
 NEW_KEYBINDINGS = create_keybindings()
 
 function insert_keybindings(repl = Base.active_repl)
-    mirepl = isdefined(repl,:mistate) ? repl.mistate : repl
+    mirepl = (isdefined(repl,:mistate) && !isnothing(repl.mistate)) ? repl.mistate : repl
     interface_modes = mirepl.interface.modes
     main_mode = interface_modes[1]
     php_idx = findfirst(Base.Fix2(isa, LineEdit.PrefixHistoryPrompt), interface_modes)


### PR DESCRIPTION
Don't really understand the change that was made as I didn't look into it, but suffice it to say it's possible for `repl.mistate` to be defined but `nothing`.  In such a case it doesn't have the field `interface` and so OhMyREPL crashes on the next line.  This adds a check for whether that field is `nothing` and does whatever it would do if it weren't defined.  Not 100% confident this is the intended behavior but seems to work fine.  I suspect that the `isdefined(repl,:mistate)` can be removed entirely, but I really don't know, so I left it in.