### PR TITLE
Fix Markdown print error in `1.12.0-DEV`

### DIFF
--- a/src/MarkdownHighlighter.jl
+++ b/src/MarkdownHighlighter.jl
@@ -5,6 +5,8 @@ import Markdown
 import .OhMyREPL.Passes.SyntaxHighlighter.SYNTAX_HIGHLIGHTER_SETTINGS
 import .OhMyREPL.HIGHLIGHT_MARKDOWN
 
+split_lines(s::AbstractString) = isdefined(Markdown, :lines) ? Markdown.lines(s) : split(s, '\n')
+
 function Markdown.term(io::IO, md::Markdown.Code, columns)
     code = md.code
     # Want to remove potential.
@@ -52,7 +54,7 @@ function Markdown.term(io::IO, md::Markdown.Code, columns)
             print(buff, output)
 
             str = String(take!(buff))
-            lines = Markdown.lines(str)
+            lines = split_lines(str)
             for li in eachindex(lines)
                 print(io, " "^Markdown.margin, lines[li])
                 li < lastindex(lines) && println(io)
@@ -62,7 +64,7 @@ function Markdown.term(io::IO, md::Markdown.Code, columns)
         end
     else
         Base.with_output_color(:cyan, io) do io
-            lines = Markdown.lines(md.code)
+            lines = split_lines(md.code)
             for i in eachindex(lines)
                 print(io, " "^Markdown.margin, lines[i])
                 i < lastindex(lines) && println(io)


### PR DESCRIPTION
Fix #357 corresponding to https://github.com/JuliaLang/julia/pull/51928
where `Markdown.lines` has been removed:

https://github.com/JuliaLang/julia/blob/3a35aec36d13c3e651c97bac664da2e778d591ad/stdlib/Markdown/src/render/terminal/formatting.jl#L10