### PR TITLE
fix macro highlighting

### DIFF
--- a/src/passes/SyntaxHighlighter.jl
+++ b/src/passes/SyntaxHighlighter.jl
@@ -152,7 +152,7 @@ function (highlighter::SyntaxHighlighterSettings)(crayons::Vector{Crayon}, token
                 crayons[i-1] = cscheme.function_def
             end
         # @fdsafds
-        elseif kind(t) == K"Identifier" && kind(prev_t) == K"@"
+        elseif kind(t) == K"MacroName"
             crayons[i-1] = cscheme._macro
             crayons[i] = cscheme._macro
         # 2] = 32.32


### PR DESCRIPTION
Macro highlighting wasn't working because JuliaSyntax uses `MacroName` instead of `Identifier`.
```julia
julia> using JuliaSyntax

julia> tokenize("@my_macro")
2-element Vector{Token}:
 Token(JuliaSyntax.SyntaxHead(K"@", 0x0001), 0x00000001:0x00000001)
 Token(JuliaSyntax.SyntaxHead(K"MacroName", 0x0000), 0x00000002:0x00000009)
```