### PR TITLE
Fix `jldoctest` blocks without `julia>` not getting rendered

### DIFF
--- a/src/MarkdownHighlighter.jl
+++ b/src/MarkdownHighlighter.jl
@@ -14,7 +14,7 @@ function Markdown.term(io::IO, md::Markdown.Code, columns)
     outputs = String[]
     sourcecodes = String[]
     do_syntax = false
-    if occursin(r"jldoctest;?", lang) || lang == "julia-repl"
+    if (occursin(r"jldoctest;?", lang) && contains(code, "julia> ")) || lang == "julia-repl"
         do_syntax = true
         code_blocks = split("\n" * code, "\njulia> ")
         for codeblock in code_blocks[2:end] #
@@ -31,7 +31,7 @@ function Markdown.term(io::IO, md::Markdown.Code, columns)
             push!(sourcecodes, string(sourcecode))
             push!(outputs, string(output))
         end
-    elseif lang == "julia" || lang == ""
+    elseif lang == "julia" || lang == "" || occursin(r"jldoctest;?", lang) 
         do_syntax = true
         push!(sourcecodes, code)
         push!(outputs, "")


### PR DESCRIPTION
When choosing whether to highlight in `julia` or `julia-repl`, this now checks whether the code block has REPL blocks (`julia>`).  If it does, it goes to `julia-repl` highlighting, otherwise it goes to `julia` highlighting.

Fix #293